### PR TITLE
Integration Tests

### DIFF
--- a/quality-metrics/new/qm-000-integration-tests.md
+++ b/quality-metrics/new/qm-000-integration-tests.md
@@ -14,19 +14,21 @@ There should be at least one of the following with integration testing:
 
 With integration testing you can verify via test-kitchen that the cookbook does what you expect it to do, without checking it by hand.
 
-Integration testing is pinical to velocity and verifing community cookbooks are what we expect them to be.
+Integration testing is pinnacle to velocity and verifying community cookbooks are what we expect them to be.
 
 ### Verification
 
 Pseudocode or actual code that can be used to automatically verify the rule and/or assign appropriate points.
 
-  find test/integration/default/ --name *_spec.rb > 3
+```bash
+   [ $(find test/integration/default/ -name '*_spec.rb' | wc -l) -ge $(find recipes/ -name '*.rb' | wc -l ) ]
+```
 
 ### Points
 
-* Positive Points:  50
-* Negative Points: 10
+* Positive Points: TBD
+* Negative Points: TBD
 
-Fifty points will be awarded if the quality metric is met.
+TBD points will be awarded if the quality metric is met.
 
-Ten points will be deducted if the quality metric is not met.
+TBD points will be deducted if the quality metric is not met.

--- a/quality-metrics/new/qm-000-integration-tests.md
+++ b/quality-metrics/new/qm-000-integration-tests.md
@@ -1,0 +1,32 @@
+---
+SMQM: UNASSIGNED
+Author: JJ Asghar <jj@chefio>
+Status: Draft
+License: Apache 2.0
+---
+
+# Integration Testing
+
+There should be at least one of the following with integration testing:
+* serverspec
+* bats
+* TBD
+
+With integration testing you can verify via test-kitchen that the cookbook does what you expect it to do, without checking it by hand.
+
+Integration testing is pinical to velocity and verifing community cookbooks are what we expect them to be.
+
+### Verification
+
+Pseudocode or actual code that can be used to automatically verify the rule and/or assign appropriate points.
+
+  find test/integration/default/ --name *_spec.rb > 3
+
+### Points
+
+* Positive Points:  50
+* Negative Points: 10
+
+Fifty points will be awarded if the quality metric is met.
+
+Ten points will be deducted if the quality metric is not met.


### PR DESCRIPTION
Having Integration tests are vital to verifying cookbooks. We should award significant points to having them but not dock too much on not having them.
