### PR TITLE
Remove points until we can see the big picture

### DIFF
--- a/quality-metrics/qm-001-published.md
+++ b/quality-metrics/qm-001-published.md
@@ -20,12 +20,3 @@ This is pseudocode
     it 'is published to the supermarket' do
       expect((cookbook.deprecated? && cookbook.up_for_adoption?)).to be false
     end
-
-### Points
-
-* Positive Points:  1
-* Negative Points: 100 if deprecated, 25 if up for adoption
-
-One point will be awarded if the quality metric is met.
-
-One hundred points will be deducted if the cookbook has been deprecated.  Twenty five points will be deducted if the cookbook is up for adoption.

--- a/quality-metrics/qm-002-name.md
+++ b/quality-metrics/qm-002-name.md
@@ -18,12 +18,3 @@ Pseudocode or actual code that can be used to automatically verify the rule and/
     it 'has a name' do
       expect(cookbook.name).to_not be_nil
     end
-
-### Points
-
-* Positive Points:  1
-* Negative Points: 100
-
-One point will be awarded if the quality metric is met.
-
-One hundred points will be deducted if the quality metric is not met.

--- a/quality-metrics/qm-003-maintainer.md
+++ b/quality-metrics/qm-003-maintainer.md
@@ -18,12 +18,3 @@ Pseudocode or actual code that can be used to automatically verify the rule and/
     it 'has a maintainer' do
       expect(cookbook.maintainer).to_not be_nil
     end
-
-### Points
-
-* Positive Points:  1
-* Negative Points: 10
-
-One point will be awarded if the quality metric is met.
-
-Ten points will be deducted if the quality metric is not met.

--- a/quality-metrics/qm-004-collaborators.md
+++ b/quality-metrics/qm-004-collaborators.md
@@ -17,12 +17,3 @@ Pseudocode or actual code that can be used to automatically verify the rule and/
 
     points = cookbook.collaborators.count
     points = 5 if points > 5
-
-### Points
-
-* Positive Points:  1-5, one point for each collaborator up to a maximum of 5 points.
-* Negative Points: 0
-
-Positive points will be awarded if the quality metric is met.
-
-No points will be deducted if the quality metric is not met.

--- a/quality-metrics/qm-005-license.md
+++ b/quality-metrics/qm-005-license.md
@@ -25,12 +25,3 @@ Pseudocode or actual code that can be used to automatically verify the rule and/
     it 'has an open source license' do
       expect(cookbook_version.license).to match(/Apache 2.0|apache2|GNU Public License 2.0|gplv2|GNU Public License 3.0|gplv3|MIT/i)
     end
-
-### Points
-
-* Positive Points:  1
-* Negative Points: 100
-
-One point will be awarded if the quality metric is met.
-
-One hundred points will be deducted if the quality metric is not met.

--- a/quality-metrics/qm-006-maintainer_email.md
+++ b/quality-metrics/qm-006-maintainer_email.md
@@ -18,12 +18,3 @@ Pseudocode or actual code that can be used to automatically verify the rule and/
     it 'has a maintainer_email' do
       expect(cookbook.maintainer_email).to_not be_nil
     end
-
-### Points
-
-* Positive Points:  1
-* Negative Points: 20
-
-One point will be awarded if the quality metric is met.
-
-Ten points will be deducted if the quality metric is not met.

--- a/quality-metrics/qm-007-version.md
+++ b/quality-metrics/qm-007-version.md
@@ -9,7 +9,7 @@ License: Apache 2.0
 
 The cookbook sets a version other than `0.0.0` in its metadata.
 
-Cookbooks without a version specified in their metadata will default to `0.0.0`.  
+Cookbooks without a version specified in their metadata will default to `0.0.0`.
 
 ### Verification
 
@@ -18,12 +18,3 @@ Pseudocode or actual code that can be used to automatically verify the rule and/
     it 'has a version' do
       expect(cookbook.version).to_not eq("0.0.0")
     end
-
-### Points
-
-* Positive Points:  1
-* Negative Points: 20
-
-One points will be awarded if the quality metric is met.
-
-Ten points will be deducted if the quality metric is not met.

--- a/quality-metrics/template.md
+++ b/quality-metrics/template.md
@@ -22,12 +22,3 @@ Pseudocode or actual code that can be used to automatically verify the rule and/
     it 'meets the rule' do
       expect(something).to be true
     end
-
-### Points
-
-* Positive Points:  1
-* Negative Points: 100
-
-Positive points will be awarded if the quality metric is met.
-
-Negative points will be deducted if the quality metric is not met.


### PR DESCRIPTION
Most conversations right now are revolving around the point values for
each check. These aren't very productive conversations right now since
we can't see the big picture to know what the total point count is.  I
propose we shelf the points concept until we have a clear picture of
what the MVP quality metrics are.  From there we can determine an
initial total and what share of that total each metric should comprise.
