### PR TITLE
Cookbook documents its attributes

### DIFF
--- a/quality-metrics/new/qm-000-interface.md
+++ b/quality-metrics/new/qm-000-interface.md
@@ -1,0 +1,29 @@
+---
+SMQM: UNASSIGNED
+Author: Clinton Wolfe <clinton@omniti.com>
+Status: Draft
+License: Apache 2.0
+---
+
+# Cookbook documents its attributes
+
+The cookbook documents the attributes that it defines or uses.
+
+Attributes definitions will be sought in the attributes/*.rb files, if any.
+
+Attribute usage will be sought in the recipes and templates.
+
+For each attribute referenced, there must be a mention in the README.
+
+Cookbook consumers should have a clear reference for the attributes that the cookbook expects.
+
+### Verification
+
+Pseudocode:
+
+    readme = read_readme(cookbook)
+    it 'documents its attributes' do
+      find_all_attributes(cookbook).each do |attribute_name|
+        expect(readme).to contain attribute_name
+      end
+    end


### PR DESCRIPTION
Seek out attribute access, and insist they are mentioned in the README.

Several gross things here make this hard to implement - ideas welcome:
- We'll never detect all attribute accesses, as it is easy to do a set-by-hash, etc.
- I'm glossing over what is an "attribute name"
- Some people document attributes as node[foo], some as default[foo], some with symbols
- Really, unless there is a set format, parsing the README to find an attribute mention may be hopeless.
- I personally like to mention when I am setting attributes to be used by a dependent cookbook, but others may want to hide that as an implementation detail.

Could be implemented as a 0..1 metric, with 1 representing 100% documentation.
