### PR TITLE
Cookbook does not contain binaries

### DIFF
--- a/quality-metrics/new/qm-000-interface.md
+++ b/quality-metrics/new/qm-000-interface.md
@@ -1,0 +1,27 @@
+---
+SMQM: UNASSIGNED
+Author: Clinton Wolfe <clintons@omniti.com>
+Status: Draft
+License: Apache 2.0
+---
+
+# Cookbook does not contain binaries
+
+The cookbook should not contain any binary files.
+
+Cookbook consumers should be able to examine the contents of the
+cookbook's source code in order to evaluate its actions and security
+implications.
+
+Community cookbooks that need to install binaries should obtain them
+from signed artifact repositories.
+
+### Verification
+
+Pseudocode:
+
+    it 'does not contain binaries' do
+      list_all_files(cookbook).each do |file|
+         expect(file).to_not be binary
+      end
+    end


### PR DESCRIPTION
No binaries allowed in community cookbooks.

Are there legit use cases for binaries in a public cookbook? (I have seen it used, usually as a workaround to not having a real artifact server, in private cookbooks).

Does Supermarket already reject binaries?
