### PR TITLE
Switch from Rubocop to Cookstyle

### DIFF
--- a/SMQM.md
+++ b/SMQM.md
@@ -2,21 +2,21 @@
 
 This file lists each quality metric.
 
-SMQM|Name|Status
-----|----|------
-001|Published to the Supermarket|Accepted
-002|Cookbook has collaborators on the Supermarket|Implemented
-003|Cookbook has an open source license|Accepted
-004|Cookbook lists address for issues|Accepted
-005|Cookbook lists a source address for repository|Accepted
-006|Cookbook lists at least one platform it supports|Accepted
-007|Cookbook includes integration tests|Accepted
-008|Cookbook Passes Rubocop|Accepted
-009|Cookbook Passes Foodcritic|Implemented
-010|Cookbook Supports Multiple Platforms|Accepted
-011|Cookbook Includes CONTRIBUTING.MD file|Accepted
-012|Cookbook does not contain binaries|Accepted
-013|Cookbook Includes TESTING.MD File|Accepted
-014|Cookbook source has a tag matching cookbook version|Accepted
+SMQM | Name                                                | Status
+---- | --------------------------------------------------- | -----------
+001  | Published to the Supermarket                        | Accepted
+002  | Cookbook has collaborators on the Supermarket       | Implemented
+003  | Cookbook has an open source license                 | Accepted
+004  | Cookbook lists address for issues                   | Accepted
+005  | Cookbook lists a source address for repository      | Accepted
+006  | Cookbook lists at least one platform it supports    | Accepted
+007  | Cookbook includes integration tests                 | Accepted
+008  | Cookbook Passes Cookstyle                           | Accepted
+009  | Cookbook Passes Foodcritic                          | Implemented
+010  | Cookbook Supports Multiple Platforms                | Accepted
+011  | Cookbook Includes CONTRIBUTING.MD file              | Accepted
+012  | Cookbook does not contain binaries                  | Accepted
+013  | Cookbook Includes TESTING.MD File                   | Accepted
+014  | Cookbook source has a tag matching cookbook version | Accepted
 
 See the [README](README.md) for more information on the various states of a quality metric.

--- a/quality-metrics/qm-008-cookstyle.md
+++ b/quality-metrics/qm-008-cookstyle.md
@@ -5,14 +5,16 @@ Status: Accepted
 License: Apache 2.0
 ---
 
-# Cookbook Passes Rubocop
+# Cookbook Passes Cookstyle
 
-The cookbook should pass Rubocop lint testing.
+The cookbook should pass cookstyle lint testing.
 
 Code that follows common standards is easier to read, write, and maintain.
 
-### Verification
+## Verification
 
 This is pseudocode:
 
-    `rubocop . --lint`
+```shell
+`cookstyle . --lint`
+```


### PR DESCRIPTION
We’re not using Rubocop directly anymore

Signed-off-by: Tim Smith <tsmith@chef.io>