### PR TITLE
revises integration test qm

### DIFF
--- a/quality-metrics/qm-007-integration-tests.md
+++ b/quality-metrics/qm-007-integration-tests.md
@@ -22,5 +22,5 @@ Integration testing is pinnacle to velocity and verifying community cookbooks do
 Pseudocode or actual code that can be used to automatically verify the rule and/or assign appropriate points.
 
 ```bash
-   [ $(find test/integration/default/ -name '*_spec.rb' | wc -l) -ge $(find recipes/ -name '*.rb' | wc -l ) ]
+   [ $(find test/integration/ -name '*_spec.rb' | wc -l) -ge $(find recipes/ -name '*.rb' | wc -l ) ]
 ```


### PR DESCRIPTION
As I have begun implementation of this metric, I've realized there are many well used community cookbooks which have their integration tests in tests/integration but NOT tests/integration/default.  I believe this metric should be changed, and that the integration tests should only need to be in test/integration (which can have any associated sub directories) and not tests/integration/default.

Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>