### PR TITLE
update license metric to include a larger list of open source licenses

### DIFF
--- a/quality-metrics/qm-003-license.md
+++ b/quality-metrics/qm-003-license.md
@@ -9,14 +9,9 @@ License: Apache-2.0
 
 Cookbook is licensed using an open source license.
 
-Acceptable licenses are:
-
-* Apache-2.0, Apache 2.0, apachev2
-* MIT, mit
-* GPL-2.0, GNU Public License 2.0, gplv2
-* GPL-3.0, GNU Public License 3.0, gplv3
-
-Licenses listed using the [SPDX License Identifiers](https://spdx.org/licenses/) are preferred.
+Acceptable licenses are any OSI-approved open source license. The [Software
+Package Data Exchange® (SPDX®) specification](https://spdx.org/licenses/) will
+be used to identify licenses and their approval status with the OSI.
 
 Cookbooks without open source licenses may not be modifiable and may not even be legally used by consumers.
 
@@ -25,5 +20,6 @@ Cookbooks without open source licenses may not be modifiable and may not even be
 Pseudocode or actual code that can be used to automatically verify the rule and/or assign appropriate points.
 
     it 'has an open source license' do
-      expect(cookbook_version.license).to match(/Apache-2.0|Apache 2.0|apachev2|MIT|mit|GPL-2.0|GNU Public License 2.0|gplv2|GPL-3.0|GNU Public License 3.0|gplv3/i)
+      expect(collection_of_osi_approved_license_strings)
+        .to include(cookbook_version.license)
     end


### PR DESCRIPTION
Pairs with [an implementation of the license check in foodcritic](https://github.com/acrmp/foodcritic/pull/593).