### PR TITLE
put QM007 integration test check on hold

### DIFF
--- a/quality-metrics/qm-007-integration-tests.md
+++ b/quality-metrics/qm-007-integration-tests.md
@@ -1,7 +1,7 @@
 ---
 SMQM: 007
 Author: JJ Asghar <jj@chefio>
-Status: Accepted
+Status: On Hold
 License: Apache-2.0
 ---
 


### PR DESCRIPTION
Despite it's bad-ass identifier number, I propose QM007 be put on hold.

Because some cookbook publishing tools do not include test directories in the published tarball, the implementation of this check cannot depend on checking the presence of files within the tarball. Other metrics that check the presence of a file make calls to GitHub via its API if a source_url is given, but recursive walking of directories via the GitHub API is non-trivial. With the increased engineering effort to implement this metric and the debates over how the make the check accurate and valuable, I propose that we put this metric on hold until both the accuracy of the check and the notional implementation can be better defined.