### PR TITLE
update repo to new Chef OSS practices

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Order is important. The last matching pattern has the most precedence.
+
+*                                @chef/supermarket-reviewers

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 This is a system used to provide an objective measure of a number of cookbook
 quality metrics.  The system takes inspiration from [Foodcritic](http://www.foodcritic.io/).
 
+**Umbrella Project**: [Supermarket](https://github.com/chef/chef-oss-practices/blob/master/projects/supermarket.md)
+
+* **[Project State](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** Maintained
+* **Issues [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** 14 days
+* **Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** 14 days
+
 This repository is a place where the community can start collaborating on
 metrics.
 


### PR DESCRIPTION
In accordance with https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md

* update README with project state and response times
* add a CODEOWNERS to use the project Reviewers group